### PR TITLE
ci: apply zizmor security audit and pin actions to commit SHAs

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 name: General
 "on": pull_request
@@ -15,7 +16,9 @@ jobs:
           - testing-type: yamllint
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: schubergphilis/mcvs-general-action@v0.5.8
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: schubergphilis/mcvs-general-action@f52c4433add29d8eff9036bf37b5b69a2c4cf28b
         with:
           testing-type: ${{ matrix.args.testing-type }}

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -15,7 +15,7 @@ jobs:
           - testing-type: yamllint
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       # yamllint disable-line rule:line-length

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1,4 +1,3 @@
-# yamllint disable rule:line-length
 ---
 name: General
 "on": pull_request
@@ -19,6 +18,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
+      # yamllint disable-line rule:line-length
       - uses: schubergphilis/mcvs-general-action@f52c4433add29d8eff9036bf37b5b69a2c4cf28b
         with:
           testing-type: ${{ matrix.args.testing-type }}

--- a/.github/workflows/golang-releases.yml
+++ b/.github/workflows/golang-releases.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 name: golang-releases
 "on": push
@@ -28,8 +29,10 @@ jobs:
     env:
       TASK_X_REMOTE_TASKFILES: 1
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: schubergphilis/mcvs-golang-action@v3.11.24
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: schubergphilis/mcvs-golang-action@ae2f6b574119123e8ee0f457a1aace702947931b
         with:
           release-application-name: ${{ matrix.args.release-application-name }}
           release-architecture: ${{ matrix.args.release-architecture }}

--- a/.github/workflows/golang-releases.yml
+++ b/.github/workflows/golang-releases.yml
@@ -1,4 +1,3 @@
-# yamllint disable rule:line-length
 ---
 name: golang-releases
 "on": push
@@ -32,6 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
+      # yamllint disable-line rule:line-length
       - uses: schubergphilis/mcvs-golang-action@ae2f6b574119123e8ee0f457a1aace702947931b
         with:
           release-application-name: ${{ matrix.args.release-application-name }}

--- a/.github/workflows/golang-releases.yml
+++ b/.github/workflows/golang-releases.yml
@@ -28,11 +28,11 @@ jobs:
     env:
       TASK_X_REMOTE_TASKFILES: 1
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       # yamllint disable-line rule:line-length
-      - uses: schubergphilis/mcvs-golang-action@ae2f6b574119123e8ee0f457a1aace702947931b
+      - uses: schubergphilis/mcvs-golang-action@9b7db5c46231cd20ad16b41e00cd952918e63410
         with:
           release-application-name: ${{ matrix.args.release-application-name }}
           release-architecture: ${{ matrix.args.release-architecture }}

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 name: golang
 "on":
@@ -32,8 +33,10 @@ jobs:
     env:
       TASK_X_REMOTE_TASKFILES: 1
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: schubergphilis/mcvs-golang-action@v3.11.24
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: schubergphilis/mcvs-golang-action@ae2f6b574119123e8ee0f457a1aace702947931b
         env:
           test-timeout: 10m0s
         with:

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,4 +1,3 @@
-# yamllint disable rule:line-length
 ---
 name: golang
 "on":
@@ -36,6 +35,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
+      # yamllint disable-line rule:line-length
       - uses: schubergphilis/mcvs-golang-action@ae2f6b574119123e8ee0f457a1aace702947931b
         env:
           test-timeout: 10m0s

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -32,11 +32,11 @@ jobs:
     env:
       TASK_X_REMOTE_TASKFILES: 1
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       # yamllint disable-line rule:line-length
-      - uses: schubergphilis/mcvs-golang-action@ae2f6b574119123e8ee0f457a1aace702947931b
+      - uses: schubergphilis/mcvs-golang-action@9b7db5c46231cd20ad16b41e00cd952918e63410
         env:
           test-timeout: 10m0s
         with:

--- a/.github/workflows/gomod-go-version-updater.yml
+++ b/.github/workflows/gomod-go-version-updater.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 name: gomod-go-version-updater-action
 "on":
@@ -10,4 +11,4 @@ jobs:
   gomod-go-version-updater-action:
     runs-on: ubuntu-slim
     steps:
-      - uses: schubergphilis/gomod-go-version-updater-action@v0.3.5
+      - uses: schubergphilis/gomod-go-version-updater-action@c12bc6c5e4ae85e82ee346115d1657e43121c195

--- a/.github/workflows/gomod-go-version-updater.yml
+++ b/.github/workflows/gomod-go-version-updater.yml
@@ -1,4 +1,3 @@
-# yamllint disable rule:line-length
 ---
 name: gomod-go-version-updater-action
 "on":
@@ -11,4 +10,5 @@ jobs:
   gomod-go-version-updater-action:
     runs-on: ubuntu-slim
     steps:
+      # yamllint disable-line rule:line-length
       - uses: schubergphilis/gomod-go-version-updater-action@c12bc6c5e4ae85e82ee346115d1657e43121c195

--- a/.github/workflows/mcvs-golang-action-taskfile-remote-url-ref-updater.yml
+++ b/.github/workflows/mcvs-golang-action-taskfile-remote-url-ref-updater.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       # yamllint disable rule:line-length
-      - uses: schubergphilis/mcvs-golang-action-taskfile-remote-url-ref-updater@v0.2.0
+      - uses: schubergphilis/mcvs-golang-action-taskfile-remote-url-ref-updater@bac758bc0d4e3ee9b174ae4c24b43717e371f248
       # yamllint enable rule:line-length

--- a/.github/workflows/mcvs-pr-validation.yml
+++ b/.github/workflows/mcvs-pr-validation.yml
@@ -15,7 +15,7 @@ jobs:
   MCVS-PR-validation-action:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       # yamllint disable-line rule:line-length

--- a/.github/workflows/mcvs-pr-validation.yml
+++ b/.github/workflows/mcvs-pr-validation.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 name: MCVS-PR-validation-action
 "on":
@@ -15,5 +16,7 @@ jobs:
   MCVS-PR-validation-action:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: schubergphilis/mcvs-pr-validation-action@v0.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: schubergphilis/mcvs-pr-validation-action@6f153c01301ab2f92336781173b7f3a796de5f3e

--- a/.github/workflows/mcvs-pr-validation.yml
+++ b/.github/workflows/mcvs-pr-validation.yml
@@ -1,4 +1,3 @@
-# yamllint disable rule:line-length
 ---
 name: MCVS-PR-validation-action
 "on":
@@ -19,4 +18,5 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
+      # yamllint disable-line rule:line-length
       - uses: schubergphilis/mcvs-pr-validation-action@6f153c01301ab2f92336781173b7f3a796de5f3e

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,3 @@
-# yamllint disable rule:line-length
 ---
 name: zizmor
 "on":

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,7 @@ jobs:
   zizmor:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,17 @@
+# yamllint disable rule:line-length
+---
+name: zizmor
+"on":
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  zizmor:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa
+        with:
+          minimum-severity: low


### PR DESCRIPTION
## What

- Adds a `zizmor` GitHub Actions security audit workflow (`.github/workflows/zizmor.yml`) that runs on every pull request with `minimum-severity: low`, mirroring the setup in `mcvs-golang-action`.
- Resolves the findings this audit surfaces on the existing workflows:
  - **unpinned-uses**: pins every action to its full commit SHA (same versions, just immutable references).
  - **artipacked**: sets `persist-credentials: false` on all `actions/checkout` steps.
  - Adds a single `# yamllint disable-line rule:line-length` comment above each SHA-pinned `uses:` line that exceeds 80 chars. Workflows whose longest line stays within 80 (e.g. `zizmor.yml` at 79) need no suppression.

## Why

`zizmor` is a static analysis tool for GitHub Actions that catches common CI/CD security issues before they ship. Applying it here matters because:

- **Supply-chain safety**: pinning actions to commit SHAs prevents a compromised or retagged upstream release from silently running in our pipeline. Version tags are mutable; SHAs are not.
- **Credential hygiene**: `persist-credentials: false` stops the checkout token from lingering in the runner's git config, reducing the blast radius if a later step is compromised.
- **Continuous enforcement**: running the audit on every PR keeps new workflows compliant automatically, so these guarantees don't regress over time.

### Why an inline `yamllint` suppression (and not a repo config)

A SHA-pinned `uses:` line is inherently long (indent + `- uses: ` + `org/repo@` + a 40-char SHA) and can't be wrapped or shortened, so it exceeds yamllint's default 80-char `line-length` limit. Bumping `max-line-length` in a repo-level `.yamllint` does **not** work here: the `yamllint` check is run by `mcvs-general-action`, which invokes `yamllint -c ${GITHUB_ACTION_PATH}/configs/yamllint.yaml .`. The explicit `-c` forces the action's bundled `extends: default` config (max length 80) and ignores any repo config — and the action exposes no input to override it. A repo config would therefore pass locally but still fail in CI. To keep the workflows uncluttered, each exception is a single `# yamllint disable-line rule:line-length` comment (the same convention `mcvs-general-action` and `mcvs-python-action` use), rather than a `disable`/`enable` block.

Dependabot's existing `github-actions` group continues to update the SHA-pinned actions.

Verified locally against the action's own yamllint config: strict `yamllint` passes, and `zizmor --min-severity low` reports **no findings**.