### PR TITLE
feat: add pre-commit hook support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+---
+- id: graphql-linter
+  name: graphql-linter
+  description: >-
+    Lint GraphQL SDL files for syntax, best practices, and Apollo Federation
+    directives.
+  entry: graphql-linter
+  language: golang
+  files: \.(graphql|graphqls)$
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -94,3 +94,33 @@ suppressions:
   - path: "test/testdata/graphql/invalid/ignore_this.graphql"
     rules: ["require-descriptions"]
 ```
+
+## Pre-commit hook
+
+`graphql-linter` ships a [pre-commit](https://pre-commit.com) hook so schemas
+are linted automatically before every commit.
+
+Add the following to the `.pre-commit-config.yaml` in your repository:
+
+```yaml
+repos:
+  - repo: https://github.com/schubergphilis/graphql-linter
+    rev: v0.1.0
+    hooks:
+      - id: graphql-linter
+```
+
+Then install and run it:
+
+```zsh
+pre-commit install
+pre-commit run graphql-linter --all-files
+```
+
+The hook is triggered whenever a `.graphql` or `.graphqls` file is staged. It
+lints the whole project (so cross-file Apollo Federation composition is
+validated) and fails the commit when linting errors are found.
+
+Configuration and suppressions are picked up from the `.graphql-linter.yaml`
+file in the repository root, as described above.
+

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ graphql-linter --version
 ### Command-line Parameters
 
 - `-configPath string`
-  The path to the configuration file (optional, defaults to `.graphql-linter.yaml` in the current directory).
+  The path to the configuration file (optional, defaults to `.graphql-linter.yml` in the current directory).
 - `-targetPath string`
   The directory with GraphQL files that should be checked.
 - `-verbose`
@@ -78,7 +78,7 @@ go run cmd/graphql-linter/main.go \
 
 ### Example configuration file
 
-By default, the linter looks for a `.graphql-linter.yaml` file in the current directory.
+By default, the linter looks for a `.graphql-linter.yml` file in the current directory.
 
 For a full example with all options and comments, see the provided `.graphql-linter.yml.example` file in the repository root.
 
@@ -105,6 +105,7 @@ Add the following to the `.pre-commit-config.yaml` in your repository:
 ```yaml
 repos:
   - repo: https://github.com/schubergphilis/graphql-linter
+    # Replace with the latest released tag; run `pre-commit autoupdate` to bump.
     rev: v0.1.4
     hooks:
       - id: graphql-linter
@@ -121,6 +122,6 @@ The hook is triggered whenever a `.graphql` or `.graphqls` file is staged. It
 lints the whole project (so cross-file Apollo Federation composition is
 validated) and fails the commit when linting errors are found.
 
-Configuration and suppressions are picked up from the `.graphql-linter.yaml`
+Configuration and suppressions are picked up from the `.graphql-linter.yml`
 file in the repository root, as described above.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Add the following to the `.pre-commit-config.yaml` in your repository:
 ```yaml
 repos:
   - repo: https://github.com/schubergphilis/graphql-linter
-    rev: v0.1.0
+    rev: v0.1.4
     hooks:
       - id: graphql-linter
 ```


### PR DESCRIPTION
## What

Adds a [pre-commit](https://pre-commit.com) hook so `graphql-linter` can be run automatically before every commit.

Closes #46

## Changes

- Add `.pre-commit-hooks.yaml` manifest exposing a `graphql-linter` hook:
  - `language: golang` — pre-commit builds the binary via `go install ./...` (verified `go build ./...` passes).
  - `pass_filenames: false` — lints the whole project so cross-file Apollo Federation composition is validated (the linter walks the project root when run without args).
  - `files: \.(graphql|graphqls)$` — matches exactly the extensions the linter recognizes, so the hook only triggers on relevant changes.
- Document the hook in the README (config snippet + install/run instructions).

## Why no code changes are needed

The binary already:
- Walks the project root when invoked with no arguments.
- Recognizes `.graphql` / `.graphqls` files.
- Exits non-zero on lint errors (`report.Print` calls `log.Fatalf`), which pre-commit relies on to fail a commit.

## Usage

```yaml
repos:
  - repo: https://github.com/schubergphilis/graphql-linter
    rev: v0.1.4
    hooks:
      - id: graphql-linter
```

## Notes for reviewers

- The `rev` in the README points at `v0.1.4` as a placeholder — please bump it to whatever tag first contains `.pre-commit-hooks.yaml`, since pre-commit resolves hooks at a tagged rev and the file must exist at that tag.
- Could not run a live `pre-commit try-repo` end-to-end locally (pre-commit not installed), but the module builds cleanly and the manifest parses with all required fields.